### PR TITLE
sync: UI From SP10.94 && fix

### DIFF
--- a/extend/lua/SpuerUi/EUI/EUI_tooltip_server.lua
+++ b/extend/lua/SpuerUi/EUI/EUI_tooltip_server.lua
@@ -2209,9 +2209,17 @@ LuaEvents.PolicyBranchTooltip.Add( function( control )
 		else
 			tip = tip .. "[NEWLINE][NEWLINE]" .. L("TXT_KEY_POLICY_BRANCH_CANNOT_UNLOCK")
 			local eraPrereq = GameInfoTypes[ policyBranchInfo.EraPrereq ]
+			local civType = GameInfo.Civilizations[player:GetCivilizationType()].Type;
+			local bCivilizationLock = false;
+			if GameInfo.PolicyBranch_CivilizationLocked{ PolicyBranchType = policyBranchInfo.Type, CivilizationType = civType }() then
+				bCivilizationLock = true;
+			end
 			-- Not in prereq Era
 			if eraPrereq and Teams[player:GetTeam()]:GetCurrentEra() < eraPrereq then
 				tip = tip .. " " .. L("TXT_KEY_POLICY_BRANCH_CANNOT_UNLOCK_ERA", GameInfo.Eras[eraPrereq].Description)
+			-- This Civilization should never Unclock it
+			elseif bCivilizationLock then
+				tip = tip .. " " .. L("TXT_KEY_POLICY_BRANCH_CANNOT_UNLOCK_CIVILIZATION");
 			-- Don't have enough Culture Yet
 			else
 				tip = tip .. " " .. L("TXT_KEY_POLICY_BRANCH_CANNOT_UNLOCK_CULTURE", player:GetNextPolicyCost())

--- a/extend/lua/SpuerUi/EUI/ShortUnitTip.lua
+++ b/extend/lua/SpuerUi/EUI/ShortUnitTip.lua
@@ -207,9 +207,9 @@ function ShortUnitTip( unit )
 		unitTip = unitTip ..Locale.ConvertTextKey("TXT_KEY_PEDIA_COST_LABEL") .. " " .. ( costTip or Locale.ConvertTextKey("TXT_KEY_FREE") )
 	end
 
-	if GameInfo.Units[unit:GetUnitType()].ExtraMaintenanceCost > 0 then -- ExtraMaintenanceCost cost
-	   ExtraMaintenanceCost=GameInfo.Units[unit:GetUnitType()].ExtraMaintenanceCost
-		unitTip = unitTip .. " " ..Locale.ConvertTextKey("TXT_KEY_PEDIA_MAINT_LABEL") .. ExtraMaintenanceCost .."[ICON_GOLD]"
+	local iExtraMaintenanceCost = GameInfo.Units[unit:GetUnitType()].ExtraMaintenanceCost + unit:GetPromotionMaintenanceCost()
+	if iExtraMaintenanceCost ~= 0 then -- ExtraMaintenanceCost cost
+		unitTip = unitTip .. " " .. Locale.ConvertTextKey("TXT_KEY_PEDIA_MAINT_LABEL") .. iExtraMaintenanceCost .. "[ICON_GOLD]"
 	end
 
 

--- a/extend/lua/ui/InfoTooltipInclude.lua
+++ b/extend/lua/ui/InfoTooltipInclude.lua
@@ -1898,6 +1898,20 @@ function GetHelpTextForBuilding( buildingID, bExcludeName, bExcludeHeader, bNoMa
 				( " +" .. value .."%" ..L(yieldInfo.IconString) ..L("TXT_KEY_Building_PER_ERA")))
 		end
 	end
+	for row in GameInfo.Building_CityStateTradeRouteYieldModifiers(thisBuildingType) do
+		local yieldInfo = GameInfo.Yields[row.YieldType]
+		local value = row.Yield or 0
+		if yieldInfo and value > 0 then
+			insert(tips, L("TXT_KEY_CSTRPM1111") .. " +" .. value .. "%" .. L(yieldInfo.IconString))
+		end
+	end
+	for row in GameInfo.Building_CityStateTradeRouteYieldModifiersGlobal(thisBuildingType) do
+		local yieldInfo = GameInfo.Yields[row.YieldType]
+		local value = row.Yield or 0
+		if yieldInfo and value > 0 then
+			insert(tips, L("TXT_KEY_CSTRPMG") .. " +" .. value .. "%" .. L(yieldInfo.IconString))
+		end
+	end
 
 	-- Yields enhanced by Technology
 	if techFilter( enhancedYieldTech ) then
@@ -4034,6 +4048,15 @@ if Game then
 					)
 				end
 
+				-- Military Promise
+				local iMilitaryPromiseTurnLeft = Players[playerID]:GetMilitaryPromiseTurnLeft(activePlayerID)
+				if iMilitaryPromiseTurnLeft >= 0 then
+					insert( treaties, negativeOrPositiveTextColor[false] .. "[ICON_CITY_STATE]"
+							.. L"TXT_KEY_MILITARY_PROMISE"
+							.. "[ENDCOLOR]" .. inParentheses(iMilitaryPromiseTurnLeft)
+					)
+				end
+
 			end
 
 			if player.GetOpinionTable then
@@ -4749,6 +4772,10 @@ function GetHelpTextForUnit2( unitID ) -- isIncludeRequirementsInfo )
 	end
 	if maxPlayerInstances > 0 then
 		append( tips, "[COLOR_YELLOW]" .. L( "TXT_KEY_NO_ACTION_PLAYER_COUNT_MAX", maxPlayerInstances ) .. "[ENDCOLOR]" );
+	end
+
+	if not city:CanTrain(unitID) then
+		append( tips, "[COLOR_WARNING_TEXT]" .. city:CanTrainTooltip(unitID) .. "[ENDCOLOR]" );
 	end
 
 	-- Pre-written Help text

--- a/extend/lua/unitpanel/EnemyUnitPanel.lua
+++ b/extend/lua/unitpanel/EnemyUnitPanel.lua
@@ -588,17 +588,30 @@ function UpdateCombatOddsUnitVsCity(pMyUnit, pCity)
 				controlTable.Value:SetText( GetFormattedText(strText, iModifier, true, true) );
 			end
 
+			iModifier = pMyPlayer:GetTraitCityStateFriendshipModifier() + pMyUnit:GetAllyCityStateCombatModifier();
+			if (iModifier ~= 0) then
+				controlTable = g_MyCombatDataIM:GetInstance();
+				controlTable.Text:LocalizeAndSetText("TXT_KEY_EUPANEL_BONUS_CITY_STATE_FRENDSHIP");
+				controlTable.Value:SetText(GetFormattedText(strText, iModifier, true, true));
+			end
 			--Extra Resouce and Happiness Bonus
-			iModifier = pMyUnit:GetStrengthModifierFromExtraResource();
+			iModifier = pMyUnit:GetResourceCombatModifier();
 			if (iModifier ~= 0) then
 				controlTable = g_MyCombatDataIM:GetInstance();		
 				controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_RESOURCE_MODIFIER");
 				controlTable.Value:SetText( GetFormattedText(strText, iModifier, true, true) );
 			end
-			iModifier = pMyUnit:GetStrengthModifierFromExtraHappiness();
+			iModifier = pMyUnit:GetHappinessCombatModifier();
 			if (iModifier ~= 0) then
 				controlTable = g_MyCombatDataIM:GetInstance();		
 				controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_EXCESS_HAPINESS_MODIFIER");
+				controlTable.Value:SetText( GetFormattedText(strText, iModifier, true, true) );
+			end
+			-- Nearby Unit Promotion modifier
+			iModifier = pMyUnit:GetNearbyUnitPromotionBonus()
+			if (iModifier ~= 0) then
+				controlTable = g_MyCombatDataIM:GetInstance();
+				controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_UNIT_PROMOTION_NEAR_SP" );
 				controlTable.Value:SetText( GetFormattedText(strText, iModifier, true, true) );
 			end
 
@@ -797,14 +810,6 @@ function UpdateCombatOddsUnitVsCity(pMyUnit, pCity)
 				controlTable.Value:SetText( GetFormattedText(strText, iModifier, true, true) );
 			end
 
-			iModifier = pMyPlayer:GetTraitCityStateFriendshipModifier();
-			if (iModifier ~= 0) then
-				controlTable = g_MyCombatDataIM:GetInstance();
-				controlTable.Text:LocalizeAndSetText("TXT_KEY_EUPANEL_BONUS_CITY_STATE_FRENDSHIP");
-				controlTable.Value:SetText(GetFormattedText(strText, iModifier, true, true));
-			end
-
-
 			-- 重复攻击加成
 			iModifier = pMyUnit:GetMultiAttackBonusCity(pCity);
 			if (iModifier ~= 0 ) then
@@ -895,15 +900,6 @@ function UpdateCombatOddsUnitVsCity(pMyUnit, pCity)
 				controlTable.Value:SetText( GetFormattedText(strText, iModifier, true, true) );
 			end
 -----------------------------------------------------额外buff--------------------------------------------------
--- Nearby UnitClass modifier
-		if (pMyUnit:GetNearbyUnitPromotionModifierFromUnitPromotion() ~= 0) then
-				iModifier = pMyUnit:GetNearbyUnitPromotionModifierFromUnitPromotion();
-				controlTable = g_MyCombatDataIM:GetInstance();
-				controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_UNITCLASS_NEAR" );
-				controlTable.Value:SetText( GetFormattedText(strText, iModifier, true, true) );
-			end
-
-
 
 			-- Damaged unit (cannot combine with other modifiers as it is multiplicative with them)
 			iModifier = pMyUnit:GetDamageCombatModifier();
@@ -1419,19 +1415,6 @@ function UpdateCombatOddsUnitVsUnit(pMyUnit, pTheirUnit)
 				controlTable.Value:SetText( GetFormattedText(strText, iModifier, true, true) );
 			end
 
-
-
-				--  Nearby Unit Promotion modifier
-			if (pMyUnit:GetNearbyUnitPromotionModifierFromUnitPromotion() ~= 0) then
-				iModifier = pMyUnit:GetNearbyUnitPromotionModifierFromUnitPromotion();
-				controlTable = g_MyCombatDataIM:GetInstance();
-				controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_UNITCLASS_NEAR" );
-				controlTable.Value:SetText( GetFormattedText(strText, iModifier, true, true) );
-			end
-
-
-
-			
 			-- Policy Attack bonus
 			local iTurns = pMyPlayer:GetAttackBonusTurns();
 			if (iTurns > 0) then
@@ -1663,18 +1646,31 @@ function UpdateCombatOddsUnitVsUnit(pMyUnit, pTheirUnit)
 				controlTable.Value:SetText( GetFormattedText(strText, iModifier, true, true) );
 			end
 
-			--Extra Resouce and Happiness Bonus
-			iModifier = pMyUnit:GetStrengthModifierFromExtraResource();
+			iModifier = pMyPlayer:GetTraitCityStateFriendshipModifier() + pMyUnit:GetAllyCityStateCombatModifier();
 			if (iModifier ~= 0) then
-				controlTable = g_MyCombatDataIM:GetInstance();		
-				controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_RESOURCE_MODIFIER");
+				controlTable = g_MyCombatDataIM:GetInstance();
+				controlTable.Text:LocalizeAndSetText("TXT_KEY_EUPANEL_BONUS_CITY_STATE_FRENDSHIP");
 				controlTable.Value:SetText(GetFormattedText(strText, iModifier, true, true));
 			end
-			iModifier = pMyUnit:GetStrengthModifierFromExtraHappiness();
+			--Extra Resouce and Happiness Bonus
+			iModifier = pMyUnit:GetResourceCombatModifier();
 			if (iModifier ~= 0) then
 				controlTable = g_MyCombatDataIM:GetInstance();		
-				controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_EXCESS_HAPINESS_MODIFIER");
+				controlTable.Text:LocalizeAndSetText("TXT_KEY_EUPANEL_RESOURCE_MODIFIER");
 				controlTable.Value:SetText(GetFormattedText(strText, iModifier, true, true));
+			end
+			iModifier = pMyUnit:GetHappinessCombatModifier();
+			if (iModifier ~= 0) then
+				controlTable = g_MyCombatDataIM:GetInstance();		
+				controlTable.Text:LocalizeAndSetText("TXT_KEY_EUPANEL_EXCESS_HAPINESS_MODIFIER");
+				controlTable.Value:SetText(GetFormattedText(strText, iModifier, true, true));
+			end
+			-- Nearby Unit Promotion modifier
+			iModifier = pMyUnit:GetNearbyUnitPromotionBonus()
+			if (iModifier ~= 0) then
+				controlTable = g_MyCombatDataIM:GetInstance();
+				controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_UNIT_PROMOTION_NEAR_SP" );
+				controlTable.Value:SetText( GetFormattedText(strText, iModifier, true, true) );
 			end
 
 			-- 多重攻击加成
@@ -2149,15 +2145,6 @@ function UpdateCombatOddsUnitVsUnit(pMyUnit, pTheirUnit)
 				controlTable.Value:SetText( GetFormattedText(strText, iModifier, true, true) );
 			end
 
-			iModifier = pMyPlayer:GetTraitCityStateFriendshipModifier();
-			if (iModifier ~= 0) then
-				controlTable = g_MyCombatDataIM:GetInstance();
-				controlTable.Text:LocalizeAndSetText("TXT_KEY_EUPANEL_BONUS_CITY_STATE_FRENDSHIP");
-				controlTable.Value:SetText(GetFormattedText(strText, iModifier, true, true));
-			end
-
-
-
 			----------------------------------------------------------------------------
 			-- BONUSES THEIR UNIT GETS
 			----------------------------------------------------------------------------
@@ -2289,17 +2276,30 @@ function UpdateCombatOddsUnitVsUnit(pMyUnit, pTheirUnit)
 
 
 
+			iModifier = pTheirPlayer:GetTraitCityStateFriendshipModifier() + pTheirUnit:GetAllyCityStateCombatModifier();
+			if (iModifier ~= 0) then
+				controlTable = g_TheirCombatDataIM:GetInstance();
+				controlTable.Text:LocalizeAndSetText("TXT_KEY_EUPANEL_BONUS_CITY_STATE_FRENDSHIP");
+				controlTable.Value:SetText(GetFormattedText(strText, iModifier, false, true));
+			end
 			--Extra Resouce and Happiness Bonus
-			iModifier = pTheirUnit:GetStrengthModifierFromExtraResource();
+			iModifier = pTheirUnit:GetResourceCombatModifier();
 			if (iModifier ~= 0) then
 				controlTable = g_TheirCombatDataIM:GetInstance();	
 				controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_RESOURCE_MODIFIER");
 				controlTable.Value:SetText(GetFormattedText(strText, iModifier, false, true));
 			end
-			iModifier = pTheirUnit:GetStrengthModifierFromExtraHappiness();
+			iModifier = pTheirUnit:GetHappinessCombatModifier();
 			if (iModifier ~= 0) then
 				controlTable = g_TheirCombatDataIM:GetInstance();		
 				controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_EXCESS_HAPINESS_MODIFIER");
+				controlTable.Value:SetText(GetFormattedText(strText, iModifier, false, true));
+			end
+			-- Nearby Unit Promotion modifier
+			iModifier = pTheirUnit:GetNearbyUnitPromotionBonus();
+			if (iModifier ~= 0) then
+				controlTable = g_TheirCombatDataIM:GetInstance();
+				controlTable.Text:LocalizeAndSetText("TXT_KEY_EUPANEL_UNIT_PROMOTION_NEAR_SP");
 				controlTable.Value:SetText(GetFormattedText(strText, iModifier, false, true));
 			end
 			
@@ -2568,17 +2568,6 @@ function UpdateCombatOddsUnitVsUnit(pMyUnit, pTheirUnit)
 					controlTable.Value:SetText( GetFormattedText(strText, iModifier, false, true) );
 				end
 
-
-
-				-- Nearby Unit promotion modifier
-					if (pTheirUnit:GetNearbyUnitPromotionModifierFromUnitPromotion() ~= 0) then
-					iModifier = pTheirUnit:GetNearbyUnitPromotionModifierFromUnitPromotion();
-					controlTable = g_TheirCombatDataIM:GetInstance();
-					controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_UNITCLASS_NEAR" );
-					controlTable.Value:SetText( GetFormattedText(strText, iModifier, false, true) );
-				end
-
-				
 				-- Flanking bonus
 				if (not bRanged) then
 					iNumAdjacentFriends = pMyUnit:GetNumEnemyUnitsAdjacent(pTheirUnit);
@@ -2827,12 +2816,6 @@ function UpdateCombatOddsUnitVsUnit(pMyUnit, pTheirUnit)
 					end
 				end
 
-				iModifier = pTheirPlayer:GetTraitCityStateFriendshipModifier();
-				if (iModifier ~= 0) then
-					controlTable = g_TheirCombatDataIM:GetInstance();
-					controlTable.Text:LocalizeAndSetText("TXT_KEY_EUPANEL_BONUS_CITY_STATE_FRENDSHIP");
-					controlTable.Value:SetText(GetFormattedText(strText, iModifier, false, true));
-				end
 			end
 			
 			--------------------------
@@ -3148,17 +3131,30 @@ function UpdateCombatOddsCityVsUnit(myCity, theirUnit)
 			end
 
 
+			local iModifier = theirPlayer:GetTraitCityStateFriendshipModifier() + theirUnit:GetAllyCityStateCombatModifier();
+			if (iModifier ~= 0) then
+				controlTable = g_TheirCombatDataIM:GetInstance();
+				controlTable.Text:LocalizeAndSetText("TXT_KEY_EUPANEL_BONUS_CITY_STATE_FRENDSHIP");
+				controlTable.Value:SetText(GetFormattedText(strText, iModifier, false, true));
+			end
 			--Extra Resouce and Happiness Bonus
-			local iModifier = theirUnit:GetStrengthModifierFromExtraResource();
+			local iModifier = theirUnit:GetResourceCombatModifier();
 			if (iModifier ~= 0) then
 				controlTable = g_TheirCombatDataIM:GetInstance();	
 				controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_RESOURCE_MODIFIER");
 				controlTable.Value:SetText(GetFormattedText(strText, iModifier, false, true));
 			end
-			iModifier = theirUnit:GetStrengthModifierFromExtraHappiness();
+			iModifier = theirUnit:GetHappinessCombatModifier();
 			if (iModifier ~= 0) then
 				controlTable = g_TheirCombatDataIM:GetInstance();		
 				controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_EXCESS_HAPINESS_MODIFIER");
+				controlTable.Value:SetText(GetFormattedText(strText, iModifier, false, true));
+			end
+			-- Nearby Unit Promotion modifier
+			iModifier = theirUnit:GetNearbyUnitPromotionBonus();
+			if (iModifier ~= 0) then
+				controlTable = g_TheirCombatDataIM:GetInstance();
+				controlTable.Text:LocalizeAndSetText("TXT_KEY_EUPANEL_UNIT_PROMOTION_NEAR_SP");
 				controlTable.Value:SetText(GetFormattedText(strText, iModifier, false, true));
 			end
 		
@@ -3383,13 +3379,6 @@ function UpdateCombatOddsCityVsUnit(myCity, theirUnit)
 			controlTable = g_TheirCombatDataIM:GetInstance();
 			controlTable.Text:LocalizeAndSetText( "TXT_KEY_EUPANEL_CITY_SAPPED" );
 			controlTable.Value:SetText( GetFormattedText(strText, iModifier, false, true) );
-		end
-
-		iModifier = theirPlayer:GetTraitCityStateFriendshipModifier();
-		if (iModifier ~= 0) then
-			controlTable = g_TheirCombatDataIM:GetInstance();
-			controlTable.Text:LocalizeAndSetText("TXT_KEY_EUPANEL_BONUS_CITY_STATE_FRENDSHIP");
-			controlTable.Value:SetText(GetFormattedText(strText, iModifier, false, true));
 		end
 	end
 	

--- a/extend/policy/lua/SocialPolicyPopup.lua
+++ b/extend/policy/lua/SocialPolicyPopup.lua
@@ -354,6 +354,12 @@ function UpdateDisplay()
 			else
 				--thisEraLabel:SetHide(true);
 			end
+
+			local civType = GameInfo.Civilizations[player:GetCivilizationType()].Type;
+			local bCivilizationLock = false;
+			if GameInfo.PolicyBranch_CivilizationLocked{ PolicyBranchType = policyBranchInfo.Type, CivilizationType = civType }() then
+				bCivilizationLock = true;
+			end
 			
 			local lockName = "Lock"..numString;
 			local thisLock = Controls[lockName];
@@ -388,7 +394,11 @@ function UpdateDisplay()
 						--thisEraLabel:SetHide( true );
 						
 						--thisButton:SetHide( true );
-						
+					-- This Civilization should never Unclock it
+					elseif bCivilizationLock then
+						strToolTip = strToolTip .. " " .. Locale.ConvertTextKey("TXT_KEY_POLICY_BRANCH_CANNOT_UNLOCK_CIVILIZATION");
+						thisButton:SetHide( false );
+						thisButton:SetText( Locale.ConvertTextKey( "TXT_KEY_POP_ADOPT_BUTTON" ) );
 					-- Don't have enough Culture Yet
 					else
 						strToolTip = strToolTip .. " " .. Locale.ConvertTextKey("TXT_KEY_POLICY_BRANCH_CANNOT_UNLOCK_CULTURE", player:GetNextPolicyCost());

--- a/extend/xml/freetech.xml
+++ b/extend/xml/freetech.xml
@@ -7,7 +7,7 @@
 	<GameSpeeds>
 		
 		<Update>
-			<Set DealDuration="30" GrowthPercent="250" TrainPercent="250" ConstructPercent="260" CreatePercent="250" ResearchPercent="220" 
+			<Set DealDuration="30" GrowthPercent="250" SetterExtraPercent="0" TrainPercent="250" ConstructPercent="260" CreatePercent="250" ResearchPercent="220" 
 				 GoldPercent="200" BuildPercent="175" ImprovementPercent="125" GreatPeoplePercent="200" CulturePercent="250" FaithPercent="160" BarbPercent="150"
 			     FeatureProductionPercent="85" UnitHurryPercent="200" UnitTradePercent="200" GoldenAgePercent="200" MinorCivElectionFreqMod="120"
 				 OpinionDurationPercent="50" SpyRatePercent="125" RelationshipDuration="25" LeaguePercent="150" ReligiousPressureAdjacentCity="80"/>
@@ -15,7 +15,7 @@
 		</Update>
 		
 		<Update>
-			<Set DealDuration="30" GrowthPercent="150" TrainPercent="150" ConstructPercent="220" CreatePercent="210" ResearchPercent="150" 
+			<Set DealDuration="30" GrowthPercent="150" SetterExtraPercent="0" TrainPercent="150" ConstructPercent="220" CreatePercent="210" ResearchPercent="150" 
 				 GoldPercent="150" BuildPercent="125" ImprovementPercent="100" GreatPeoplePercent="150" CulturePercent="150" FaithPercent="135" BarbPercent="100"
 			     FeatureProductionPercent="75" UnitHurryPercent="150" UnitTradePercent="150" GoldenAgePercent="150" MinorCivElectionFreqMod="100"
 				 OpinionDurationPercent="50" SpyRatePercent="100" RelationshipDuration="25" LeaguePercent="100" ReligiousPressureAdjacentCity="100"/>
@@ -23,7 +23,7 @@
 		</Update>
 		
 		<Update>
-			<Set DealDuration="30" GrowthPercent="120" TrainPercent="130" ConstructPercent="190" CreatePercent="170" ResearchPercent="120" 
+			<Set DealDuration="30" GrowthPercent="120" SetterExtraPercent="0" TrainPercent="130" ConstructPercent="190" CreatePercent="170" ResearchPercent="120" 
 				 GoldPercent="120" ImprovementPercent="85" GreatPeoplePercent="130" CulturePercent="110" FaithPercent="125" BarbPercent="100"
 			     FeatureProductionPercent="60" UnitHurryPercent="115" UnitTradePercent="100" GoldenAgePercent="120" MinorCivElectionFreqMod="80"
 				 OpinionDurationPercent="50" SpyRatePercent="80" RelationshipDuration="25" LeaguePercent="80" ReligiousPressureAdjacentCity="150"/>
@@ -31,7 +31,7 @@
 		</Update>
 		
 		<Update>
-			<Set DealDuration="20" GrowthPercent="100" TrainPercent="75" ConstructPercent="100" CreatePercent="100" ResearchPercent="90" 
+			<Set DealDuration="20" GrowthPercent="100" SetterExtraPercent="0" TrainPercent="75" ConstructPercent="100" CreatePercent="100" ResearchPercent="90" 
 				 GoldPercent="75" ImprovementPercent="45" GreatPeoplePercent="67" CulturePercent="75" FaithPercent="67" BarbPercent="67"
 			     FeatureProductionPercent="40" UnitHurryPercent="75" UnitTradePercent="67" GoldenAgePercent="75" MinorCivElectionFreqMod="67"
 				 OpinionDurationPercent="50" SpyRatePercent="67" RelationshipDuration="25" LeaguePercent="67"  ReligiousPressureAdjacentCity="200"/>

--- a/extend/xml/wonder/extra wonder.xml
+++ b/extend/xml/wonder/extra wonder.xml
@@ -753,7 +753,6 @@
 			<MinAreaSize>-1</MinAreaSize>
 			<ConquestProb>100</ConquestProb>
 			<GreatPeopleRateChange>1</GreatPeopleRateChange>
-			<DisplayPosition>4</DisplayPosition>
 			<IconAtlas>ROBOT_ICON_ATLAS5</IconAtlas>
 			<PortraitIndex>246</PortraitIndex>
 			<WonderSplashImage>GateAll.dds</WonderSplashImage>
@@ -1381,7 +1380,6 @@
 			<HurryCostModifier>-1</HurryCostModifier>
 			<MinAreaSize>-1</MinAreaSize>
 			<ConquestProb>100</ConquestProb>
-			<DisplayPosition>2</DisplayPosition>
 			<IconAtlas>ROBOT_ICON_ATLAS3</IconAtlas>
 			<PortraitIndex>163</PortraitIndex>
 			<WonderSplashImage>BurjAlArab.dds</WonderSplashImage>

--- a/世界强权.civ5proj
+++ b/世界强权.civ5proj
@@ -52,7 +52,7 @@
         <Type>Mod</Type>
         <Name>CIV5MPDLL</Name>
         <Id>a2969a0a-e4da-41cc-9e0b-19b29aa971d8</Id>
-        <MinVersion>45</MinVersion>
+        <MinVersion>48</MinVersion>
         <MaxVersion>999</MaxVersion>
       </Association>
       <Association>


### PR DESCRIPTION
1.添加了一些新的UI提示(添加了建造面板单位无法训练的提示，购买时金钱/信仰不足的提示未添加)
2.替换了战斗面板部分数据接口(临近晋升加成)
3.修复了万国之门、帆船酒店建造完成后城市贴图消失的问题
4.覆盖取消了SP不同速度对移民产能的额外花费降低